### PR TITLE
Update README.md - Fix docker-hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Customizing the SSL configuration is only supported in the mysql cnf file and is
 
 ## Using Docker
 
-You can deploy this exporter using the [prom/mysqld-exporter](https://registry.hub.docker.com/u/prom/mysqld-exporter/) Docker image.
+You can deploy this exporter using the [prom/mysqld-exporter](https://registry.hub.docker.com/r/prom/mysqld-exporter/) Docker image.
 
 For example:
 


### PR DESCRIPTION
The link to the docker-hub page was 
https://registry.hub.docker.com/u/prom/mysqld-exporter/

This is an empty page so I changed it to 
https://registry.hub.docker.com/r/prom/mysqld-exporter/